### PR TITLE
Database persistance

### DIFF
--- a/resources/db-persistance.yaml
+++ b/resources/db-persistance.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: mariadb-pv
+spec:
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: /data/mariadb
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mariadb-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/resources/deployment.yaml
+++ b/resources/deployment.yaml
@@ -26,6 +26,9 @@ spec:
                   key: mysql-root-password
             - name: MYSQL_DATABASE
               value: proactive
+          volumeMounts:
+            - name: mariadb-storage
+              mountPath: /var/lib/mysql
           args: ["--wait_timeout=31536000"]
           livenessProbe:
             exec:
@@ -108,3 +111,6 @@ spec:
         - name: script-volume
           configMap:
             name: scripts-configmap
+        - name: mariadb-storage
+          persistentVolumeClaim:
+            claimName: mariadb-pvc


### PR DESCRIPTION
- for persistent volume definitions
hostPath: This example uses a host directory on the node for simplicity. In production, use a cloud-native storage solution like AWS EBS, GCP Persistent Disks, or NFS for durability.
capacity: Adjust the size (10Gi) as per your requirements.

- deployment
mountPath: directory where MariaDB stores its database files
